### PR TITLE
Adiciona modal para exibir imagem completa

### DIFF
--- a/src/app/galeria/components/full-image-modal/FullImageModal.component.tsx
+++ b/src/app/galeria/components/full-image-modal/FullImageModal.component.tsx
@@ -1,0 +1,72 @@
+import { Box, Dialog, IconButton, Stack } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+
+import { FullImageModalProps } from "./FullImageModal.types";
+
+function FullImageModal({ isOpen, onClose, src }: FullImageModalProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+  if (!src) return null;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      slotProps={{
+        backdrop: {
+          sx: {
+            backgroundColor: "rgba(255, 255, 255, 0.8)",
+          },
+        },
+        paper: {
+          sx: {
+            backgroundColor: "transparent",
+            borderRadius: 0,
+          },
+        },
+      }}
+      maxWidth={false}
+      fullScreen={fullScreen}
+    >
+      <IconButton
+        color="info"
+        onClick={onClose}
+        sx={{
+          position: "fixed",
+          top: { xs: 16, sm: 64 },
+          right: { xs: 16, sm: 64 },
+          bgcolor: "#fff",
+          "&:hover": {
+            bgcolor: "#f0f0f0",
+          },
+        }}
+      >
+        <CloseRoundedIcon />
+      </IconButton>
+
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="center"
+        height="100%"
+        padding={{ xs: 4, sm: 0 }}
+      >
+        <Box
+          component="img"
+          src={src}
+          sx={{
+            width: "auto",
+            maxWidth: "100%",
+            maxHeight: "90dvh",
+            objectFit: "contain",
+          }}
+        />
+      </Stack>
+    </Dialog>
+  );
+}
+
+export default FullImageModal;

--- a/src/app/galeria/components/full-image-modal/FullImageModal.types.ts
+++ b/src/app/galeria/components/full-image-modal/FullImageModal.types.ts
@@ -1,0 +1,5 @@
+export interface FullImageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  src: string | null;
+}


### PR DESCRIPTION
# Descrição
Este PR adiciona um modal para exibir a imagem completa ao selecionar uma no feed.

## Capturas/Gravação de tela
|Imagem|
|-|
|<img width="1897" height="912" alt="image" src="https://github.com/user-attachments/assets/aaeeee35-dcd9-4c88-a226-6bb3f6911f00" />|
