### PR TITLE
Adiciona sistema de filtro de categorias para a galeria de imagens

### DIFF
--- a/src/app/(galeria)/_components/image-gallery/ImageGallery.types.ts
+++ b/src/app/(galeria)/_components/image-gallery/ImageGallery.types.ts
@@ -1,8 +1,8 @@
-import type { Category, Image } from "@/shared/types/Image.types";
+import type { CategoryTypes, Image } from '@/shared/types/Image.types';
 
 export interface GalleryImage {
   isHighlight?: boolean;
-  category: Category;
+  category: CategoryTypes;
   images: Image[];
 }
 

--- a/src/app/(galeria)/_components/image-gallery/ImageGallery.utils.ts
+++ b/src/app/(galeria)/_components/image-gallery/ImageGallery.utils.ts
@@ -1,0 +1,11 @@
+import { Category } from '@/shared/types/Image.types';
+
+export const validateCategory = (category: unknown) => {
+  const isValidCategory = Object.values(Category).includes(
+    category as Category,
+  );
+
+  if (!isValidCategory) return null;
+
+  return category as Category;
+};

--- a/src/app/(galeria)/_components/image-gallery/__tests__/ImageGallery.test.tsx
+++ b/src/app/(galeria)/_components/image-gallery/__tests__/ImageGallery.test.tsx
@@ -1,5 +1,16 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { GalleryImage } from '../ImageGallery.types';
 import ImageGallery from '../ImageGallery.component';
+
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  useSearchParams: jest.fn().mockReturnValue({
+    get: jest.fn().mockReturnValue(null),
+  }),
+  useRouter: jest.fn().mockReturnValue({
+    replace: jest.fn(),
+  }),
+}));
 
 jest.mock('@mui/material/useMediaQuery', () =>
   jest.fn().mockReturnValue(false),
@@ -32,17 +43,20 @@ jest.mock('swiper/modules', () => ({
   Navigation: {},
 }));
 
-const mockImages = [
+const mockImages: GalleryImage[] = [
   {
     isHighlight: true,
+    category: 'nature',
     images: [{ id: '1', src: 'https://example.com/img1.jpg', alt: 'test' }],
   },
   {
     isHighlight: true,
+    category: 'nature',
     images: [{ id: '2', src: 'https://example.com/img2.jpg', alt: 'test' }],
   },
   {
     isHighlight: true,
+    category: 'nature',
     images: [{ id: '3', src: 'https://example.com/img3.jpg', alt: 'test' }],
   },
 ];

--- a/src/app/(galeria)/_components/image-gallery/image-gallery-item/ImageGalleryItem.component.tsx
+++ b/src/app/(galeria)/_components/image-gallery/image-gallery-item/ImageGalleryItem.component.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { ButtonBase, Chip, Stack, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import OpenInFullRoundedIcon from '@mui/icons-material/OpenInFullRounded';
 import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 
@@ -19,6 +20,7 @@ function ImageGalleryItem({
   ...restProps
 }: ImageGalleryItemProps) {
   const [loaded, setLoaded] = useState(false);
+  const isMobile = useMediaQuery(theme => theme.breakpoints.down('sm'));
   const theme = useTheme();
 
   return (
@@ -70,17 +72,19 @@ function ImageGalleryItem({
               },
             }}
           >
-            <Chip
-              variant="filled"
-              color={theme.palette.mode === 'light' ? 'primary' : 'default'}
-              label={CATEGORY_LABEL[category]}
-              sx={{
-                position: 'absolute',
-                top: 8,
-                left: 8,
-                borderRadius: 3,
-              }}
-            />
+            {!isMobile && (
+              <Chip
+                variant="filled"
+                color={theme.palette.mode === 'light' ? 'primary' : 'default'}
+                label={CATEGORY_LABEL[category]}
+                sx={{
+                  position: 'absolute',
+                  top: 8,
+                  left: 8,
+                  borderRadius: 3,
+                }}
+              />
+            )}
 
             <OpenInFullRoundedIcon color="secondary" />
 

--- a/src/app/(galeria)/_components/image-gallery/image-gallery-item/ImageGalleryItem.types.ts
+++ b/src/app/(galeria)/_components/image-gallery/image-gallery-item/ImageGalleryItem.types.ts
@@ -1,8 +1,8 @@
 import type { ButtonBaseProps } from '@mui/material';
-import type { Category, Image } from '@/shared/types/Image.types';
+import type { CategoryTypes, Image } from '@/shared/types/Image.types';
 
 export interface ImageGalleryItemProps extends ButtonBaseProps {
   image: Image;
   hasMultipleImages?: boolean;
-  category: Category;
+  category: CategoryTypes;
 }

--- a/src/app/(galeria)/_components/image-gallery/image-gallery-item/__tests__/ImageGalleryItem.test.tsx
+++ b/src/app/(galeria)/_components/image-gallery/image-gallery-item/__tests__/ImageGalleryItem.test.tsx
@@ -1,22 +1,32 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { CategoryTypes } from '@/shared/types/Image.types';
 import ImageGalleryItem from '../ImageGalleryItem.component';
+
+jest.mock('@mui/material/useMediaQuery', () =>
+  jest.fn().mockReturnValue(false),
+);
 
 const image = { id: '1', src: 'https://example.com/img1.jpg', alt: 'test' };
 
+const defaultProps = {
+  image,
+  category: 'nature' as CategoryTypes,
+};
+
 it('renders the image with correct alt value', () => {
-  render(<ImageGalleryItem image={image} />);
+  render(<ImageGalleryItem {...defaultProps} />);
 
   expect(screen.getByAltText(image.alt)).toBeInTheDocument();
 });
 
 it('renders the image with correct src value', () => {
-  render(<ImageGalleryItem image={image} />);
+  render(<ImageGalleryItem {...defaultProps} />);
 
   expect(screen.getByRole('img')).toHaveAttribute('src', image.src);
 });
 
 it('renders the multiple images icon when hasMultipleImages is true', async () => {
-  render(<ImageGalleryItem image={image} hasMultipleImages />);
+  render(<ImageGalleryItem {...defaultProps} hasMultipleImages />);
 
   fireEvent.load(screen.getByRole('img'));
 

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/ImagesFilterButton.component.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/ImagesFilterButton.component.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { IconButton, Tooltip } from '@mui/material';
+import FilterListRoundedIcon from '@mui/icons-material/FilterListRounded';
+
+import { CategoryTypes } from '@/shared/types/Image.types';
+
+import ImagesFilterPanel from './images-filter-panel/ImagesFilterPanel.component';
+import type { ImagesFilterButtonProps } from './ImagesFilterButton.types';
+
+function ImagesFilterButton({
+  setSelectedCategory,
+  selectedCategory,
+  hasQueryCategory,
+}: ImagesFilterButtonProps) {
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(
+    !!selectedCategory || false,
+  );
+  const { replace } = useRouter();
+
+  const handleClick = () => {
+    if (isDrawerOpen) {
+      if (hasQueryCategory) replace('/');
+
+      setSelectedCategory(null);
+    }
+
+    setIsDrawerOpen(prev => !prev);
+  };
+
+  const handleCategory = (category: CategoryTypes) => {
+    if (selectedCategory === category) {
+      setSelectedCategory(null);
+      return;
+    }
+
+    setSelectedCategory(category);
+  };
+
+  return (
+    <>
+      <Tooltip title="Filtrar Imagens" arrow>
+        <IconButton
+          data-testid="images-filter-button"
+          color={isDrawerOpen ? 'primary' : 'default'}
+          onClick={handleClick}
+          sx={{
+            position: 'fixed',
+            bottom: { xs: 12, sm: 32 },
+            right: { xs: 12, sm: 32 },
+            zIndex: 999,
+            border: 1,
+            borderColor: isDrawerOpen ? 'primary' : 'divider',
+            bgcolor: 'background.default',
+          }}
+        >
+          <FilterListRoundedIcon />
+        </IconButton>
+      </Tooltip>
+
+      <ImagesFilterPanel
+        open={isDrawerOpen}
+        selectedCategory={selectedCategory}
+        onCategoryClick={handleCategory}
+        onCloseClick={handleClick}
+      />
+    </>
+  );
+}
+
+export default ImagesFilterButton;

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/ImagesFilterButton.types.ts
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/ImagesFilterButton.types.ts
@@ -1,0 +1,8 @@
+import type { Dispatch, SetStateAction } from 'react';
+import type { CategoryTypes } from '@/shared/types/Image.types';
+
+export interface ImagesFilterButtonProps {
+  selectedCategory: CategoryTypes | null;
+  setSelectedCategory: Dispatch<SetStateAction<CategoryTypes | null>>;
+  hasQueryCategory: boolean;
+}

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/__tests__/ImagesFilterButton.component.test.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/__tests__/ImagesFilterButton.component.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import ImagesFilterButton from '../ImagesFilterButton.component';
+
+const mockedReplace = jest.fn();
+const setSelectedCategory = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockedReplace,
+  }),
+}));
+
+const defaultProps = {
+  selectedCategory: null,
+  setSelectedCategory,
+  hasQueryCategory: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('opens drawer when button is clicked', () => {
+  render(<ImagesFilterButton {...defaultProps} />);
+
+  fireEvent.click(screen.getByTestId('images-filter-button'));
+
+  expect(screen.getByTestId('images-filter-panel')).toBeInTheDocument();
+});
+
+it('closes drawer when button is clicked again', () => {
+  render(<ImagesFilterButton {...defaultProps} />);
+
+  const button = screen.getByTestId('images-filter-button');
+
+  fireEvent.click(button);
+  fireEvent.click(button);
+
+  expect(screen.queryByTestId('images-filter-panel')).not.toBeInTheDocument();
+});
+
+it('clears selected category and replaces route when closing with query category', () => {
+  render(
+    <ImagesFilterButton
+      {...defaultProps}
+      hasQueryCategory
+      selectedCategory="nature"
+    />,
+  );
+
+  fireEvent.click(screen.getByTestId('images-filter-button'));
+
+  expect(setSelectedCategory).toHaveBeenCalledWith(null);
+  expect(mockedReplace).toHaveBeenCalledWith('/');
+});
+
+it('sets category when clicking on category', () => {
+  render(<ImagesFilterButton {...defaultProps} />);
+
+  fireEvent.click(screen.getByTestId('images-filter-button'));
+  fireEvent.click(screen.getByText('Natureza'));
+
+  expect(setSelectedCategory).toHaveBeenCalledWith('nature');
+});
+
+it('clears category when clicking the same category again', () => {
+  render(<ImagesFilterButton {...defaultProps} selectedCategory="nature" />);
+
+  fireEvent.click(screen.getByText('Natureza'));
+
+  expect(setSelectedCategory).toHaveBeenCalledWith(null);
+});

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.component.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.component.tsx
@@ -1,0 +1,100 @@
+import { Chip, Divider, Drawer, IconButton, Stack } from '@mui/material';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+
+import { CATEGORY_LABEL } from '@/shared/constants';
+import { CategoryTypes } from '@/shared/types/Image.types';
+
+import type { ImagesFilterPanelProps } from './ImagesFilterPanel.types';
+
+function ImagesFilterPanel({
+  open,
+  selectedCategory,
+  onCategoryClick,
+  onCloseClick,
+}: ImagesFilterPanelProps) {
+  const actionSize = { xs: 36, sm: 32 };
+
+  if (!open) return null;
+
+  return (
+    <Drawer
+      data-testid="images-filter-panel"
+      variant="persistent"
+      open
+      data-open={open}
+      anchor="bottom"
+      hideBackdrop
+      slotProps={{
+        paper: {
+          sx: {
+            mx: 'auto',
+            my: { xs: 0, sm: 4 },
+            borderRadius: { xs: 0, sm: 12 },
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.default',
+            width: { xs: '100%', sm: 'fit-content' },
+          },
+        },
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={4}
+        paddingX={{ xs: 2, sm: 4 }}
+        paddingY={{ xs: 3, sm: 4 }}
+      >
+        <Stack
+          width="100%"
+          sx={{
+            overflow: 'hidden',
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={{ xs: 2, sm: 4 }}
+            sx={{
+              overflowX: 'auto',
+            }}
+          >
+            {(Object.entries(CATEGORY_LABEL) as [CategoryTypes, string][]).map(
+              ([key, value]) => {
+                const isSelected = selectedCategory === key;
+
+                return (
+                  <Chip
+                    role="checkbox"
+                    aria-checked={isSelected}
+                    color={isSelected ? 'primary' : 'default'}
+                    onClick={() => onCategoryClick(key)}
+                    key={key}
+                    label={value}
+                    clickable
+                  />
+                );
+              },
+            )}
+          </Stack>
+        </Stack>
+
+        <Divider orientation="vertical" flexItem />
+
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <IconButton
+            onClick={onCloseClick}
+            sx={{
+              width: actionSize,
+              height: actionSize,
+            }}
+          >
+            <CloseRoundedIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      </Stack>
+    </Drawer>
+  );
+}
+
+export default ImagesFilterPanel;

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.types.ts
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.types.ts
@@ -1,0 +1,8 @@
+import type { CategoryTypes } from '@/shared/types/Image.types';
+
+export interface ImagesFilterPanelProps {
+  open: boolean;
+  selectedCategory: CategoryTypes | null;
+  onCategoryClick: (key: CategoryTypes) => void;
+  onCloseClick: () => void;
+}

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/__tests__/ImagesFilterPanel.component.test.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/__tests__/ImagesFilterPanel.component.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import ImagesFilterPanel from '../ImagesFilterPanel.component';
+import { CATEGORY_LABEL } from '@/shared/constants';
+
+const onCategoryClick = jest.fn();
+const onCloseClick = jest.fn();
+
+const defaultProps = {
+  open: true,
+  selectedCategory: null,
+  onCategoryClick,
+  onCloseClick,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('does not render when open is false', () => {
+  render(<ImagesFilterPanel {...defaultProps} open={false} />);
+
+  expect(screen.queryByTestId('images-filter-panel')).not.toBeInTheDocument();
+});
+
+it('renders when open is true', () => {
+  render(<ImagesFilterPanel {...defaultProps} />);
+
+  expect(screen.getByTestId('images-filter-panel')).toBeInTheDocument();
+});
+
+it.each(Object.values(CATEGORY_LABEL))('renders the %p category chips', label => {
+  render(<ImagesFilterPanel {...defaultProps} />);
+
+  expect(screen.getByText(label)).toBeInTheDocument();
+});
+
+it('marks the selected category as checked', () => {
+  render(<ImagesFilterPanel {...defaultProps} selectedCategory="nature" />);
+
+  const selectedChip = screen.getByRole('checkbox', {
+    name: CATEGORY_LABEL.nature,
+  });
+
+  expect(selectedChip).toHaveAttribute('aria-checked', 'true');
+});
+
+it('calls onCategoryClick with category key when clicking a chip', () => {
+  render(<ImagesFilterPanel {...defaultProps} />);
+
+  fireEvent.click(screen.getByText(CATEGORY_LABEL.nature));
+
+  expect(onCategoryClick).toHaveBeenCalledWith('nature');
+});
+
+it('calls onCloseClick when clicking the close button', () => {
+  render(<ImagesFilterPanel {...defaultProps} />);
+
+  const closeButton = screen.getByRole('button');
+
+  fireEvent.click(closeButton);
+
+  expect(onCloseClick).toHaveBeenCalled();
+});

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -45,7 +45,7 @@ export const initialImages = [
   },
   {
     isHighlight: false,
-    category: Category.ESSAY,
+    category: Category.STREET_PHOTOGRAPHY,
     images: [
       {
         id: 'img7',
@@ -67,7 +67,7 @@ export const initialImages = [
   },
   {
     isHighlight: false,
-    category: Category.STREET_PHOTOGRAPHY,
+    category: Category.VEHICLE,
     images: [
       {
         id: 'img12',
@@ -624,7 +624,7 @@ export const initialImages = [
     images: [
       {
         id: 'img65',
-        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1767362261/davhyandrade-gallery/_MG_6504_sata39.jpg',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768608648/davhyandrade-gallery/_MG_6504_npxvyz.jpg',
         alt: 'test',
       },
     ],
@@ -1034,6 +1034,184 @@ export const initialImages = [
       {
         id: 'img109',
         src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1767365673/davhyandrade-gallery/_MG_2629-2_hl7hnj.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.ESSAY,
+    images: [
+      {
+        id: 'img111',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768606877/davhyandrade-gallery/_MG_7915_ushr9u.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img112',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768606877/davhyandrade-gallery/_MG_7916_eup7fw.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.ESSAY,
+    images: [
+      {
+        id: 'img114',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768606877/davhyandrade-gallery/_MG_7922-2_axbcii.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img115',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768683094/davhyandrade-gallery/_MG_7922_evvosy.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.ESSAY,
+    images: [
+      {
+        id: 'img116',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768606881/davhyandrade-gallery/_MG_7958_dnrzkm.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img1171',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768606878/davhyandrade-gallery/_MG_7958-2_phirto.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img117',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685612/davhyandrade-gallery/_MG_6998_wybwui.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img118',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685613/davhyandrade-gallery/_MG_7809_fwsk5u.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img119',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_7813_k5mzek.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img120',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685613/davhyandrade-gallery/_MG_7076_x1tlis.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img121',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_7072_feq9zg.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img121',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685613/davhyandrade-gallery/_MG_7748_huadgw.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img122',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685613/davhyandrade-gallery/_MG_7194_mushck.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img123',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685613/davhyandrade-gallery/_MG_7969_frhqr6.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img124',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685613/davhyandrade-gallery/_MG_7768_nhqfhz.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img125',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_7891_mb9m3f.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img126',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_6696_eumf1f.jpg',
+        alt: 'test',
+      },
+    ],
+  },
+  {
+    isHighlight: false,
+    category: Category.STREET_PHOTOGRAPHY,
+    images: [
+      {
+        id: 'img127',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_7185_xxsoqq.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img128',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_7188_ih87hn.jpg',
+        alt: 'test',
+      },
+      {
+        id: 'img129',
+        src: 'https://res.cloudinary.com/dbsebu2ef/image/upload/v1768685614/davhyandrade-gallery/_MG_7189_svb5g6.jpg',
         alt: 'test',
       },
     ],

--- a/src/shared/types/Image.types.ts
+++ b/src/shared/types/Image.types.ts
@@ -5,6 +5,12 @@ export enum Category {
   ESSAY = 'essay',
 }
 
+export type CategoryTypes =
+  | 'nature'
+  | 'street-photography'
+  | 'vehicle'
+  | 'essay';
+
 export type Image = {
   id: string;
   src: string;


### PR DESCRIPTION
# Descrição

Este PR implementa sistema de filtro de categorias para a galeria de imagens. Adiciona botão flutuante que abre um painel com chips de categorias, permitindo filtrar imagens por categoria. O filtro suporta parâmetros de URL via query string `?category=`, mantendo o estado inicial da categoria selecionada. Em dispositivos móveis, as badges de categoria nos itens da galeria são ocultadas para melhor experiência visual.

## Como isso foi testado?

- Testes Manuais
- Testes Unitários