### PR TITLE
Adiciona botão de compartilhar filtro

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,9 @@ const config: Config = {
   testEnvironment: 'jsdom',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };
 
 export default createJestConfig(config);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "19.1.0",
     "react-lazy-load-image-component": "^1.6.3",
     "react-responsive-masonry": "^2.7.1",
+    "react-toastify": "^11.0.5",
     "swiper": "^12.0.3"
   },
   "devDependencies": {

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/ImagesFilterButton.component.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/ImagesFilterButton.component.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { IconButton, Tooltip } from '@mui/material';
 import FilterListRoundedIcon from '@mui/icons-material/FilterListRounded';
 
+import useClipboard from '@/shared/hooks/use-clipboard/useClipboard.hooks';
 import { CategoryTypes } from '@/shared/types/Image.types';
 
 import ImagesFilterPanel from './images-filter-panel/ImagesFilterPanel.component';
@@ -20,6 +21,9 @@ function ImagesFilterButton({
     !!selectedCategory || false,
   );
   const { replace } = useRouter();
+  const { copy, isClipboardSupported } = useClipboard({
+    message: 'Link copiado com sucesso!',
+  });
 
   const handleClick = () => {
     if (isDrawerOpen) {
@@ -38,6 +42,12 @@ function ImagesFilterButton({
     }
 
     setSelectedCategory(category);
+  };
+
+  const handleShareButton = (category: CategoryTypes | null) => {
+    const categoryQueryParam = category ? `?category=${category}` : '';
+
+    copy(`${window.location.origin}${categoryQueryParam}`);
   };
 
   return (
@@ -66,6 +76,8 @@ function ImagesFilterButton({
         selectedCategory={selectedCategory}
         onCategoryClick={handleCategory}
         onCloseClick={handleClick}
+        onShareClick={handleShareButton}
+        isClipboardSupported={isClipboardSupported}
       />
     </>
   );

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/__tests__/ImagesFilterButton.component.test.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/__tests__/ImagesFilterButton.component.test.tsx
@@ -11,6 +11,16 @@ jest.mock('next/navigation', () => ({
   }),
 }));
 
+const mockCopy = jest.fn();
+
+jest.mock('@/shared/hooks/use-clipboard/useClipboard.hooks', () => ({
+  __esModule: true,
+  default: () => ({
+    copy: mockCopy,
+    isClipboardSupported: true,
+  }),
+}));
+
 const defaultProps = {
   selectedCategory: null,
   setSelectedCategory,
@@ -70,4 +80,12 @@ it('clears category when clicking the same category again', () => {
   fireEvent.click(screen.getByText('Natureza'));
 
   expect(setSelectedCategory).toHaveBeenCalledWith(null);
+});
+
+it('calls copy function when clicking share button', () => {
+  render(<ImagesFilterButton {...defaultProps} selectedCategory="nature" />);
+
+  fireEvent.click(screen.getByTestId('share-button'));
+
+  expect(mockCopy).toHaveBeenCalledWith('http://localhost?category=nature');
 });

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.component.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.component.tsx
@@ -1,5 +1,6 @@
 import { Chip, Divider, Drawer, IconButton, Stack } from '@mui/material';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import ShareRoundedIcon from '@mui/icons-material/ShareRounded';
 
 import { CATEGORY_LABEL } from '@/shared/constants';
 import { CategoryTypes } from '@/shared/types/Image.types';
@@ -11,6 +12,8 @@ function ImagesFilterPanel({
   selectedCategory,
   onCategoryClick,
   onCloseClick,
+  onShareClick,
+  isClipboardSupported,
 }: ImagesFilterPanelProps) {
   const actionSize = { xs: 36, sm: 32 };
 
@@ -82,7 +85,22 @@ function ImagesFilterPanel({
         <Divider orientation="vertical" flexItem />
 
         <Stack direction="row" alignItems="center" spacing={2}>
+          {isClipboardSupported && (
+            <IconButton
+              data-testid="share-button"
+              onClick={() => onShareClick(selectedCategory)}
+              sx={{
+                width: actionSize,
+                height: actionSize,
+                fontSize: 18,
+              }}
+            >
+              <ShareRoundedIcon fontSize="inherit" />
+            </IconButton>
+          )}
+
           <IconButton
+            data-testid="close-button"
             onClick={onCloseClick}
             sx={{
               width: actionSize,

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.types.ts
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/ImagesFilterPanel.types.ts
@@ -5,4 +5,6 @@ export interface ImagesFilterPanelProps {
   selectedCategory: CategoryTypes | null;
   onCategoryClick: (key: CategoryTypes) => void;
   onCloseClick: () => void;
+  onShareClick: (category: CategoryTypes | null) => void;
+  isClipboardSupported: boolean;
 }

--- a/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/__tests__/ImagesFilterPanel.component.test.tsx
+++ b/src/app/(galeria)/_components/image-gallery/images-filter-button/images-filter-panel/__tests__/ImagesFilterPanel.component.test.tsx
@@ -5,12 +5,15 @@ import { CATEGORY_LABEL } from '@/shared/constants';
 
 const onCategoryClick = jest.fn();
 const onCloseClick = jest.fn();
+const onShareClick = jest.fn();
 
 const defaultProps = {
   open: true,
   selectedCategory: null,
   onCategoryClick,
   onCloseClick,
+  onShareClick,
+  isClipboardSupported: true,
 };
 
 beforeEach(() => {
@@ -29,11 +32,14 @@ it('renders when open is true', () => {
   expect(screen.getByTestId('images-filter-panel')).toBeInTheDocument();
 });
 
-it.each(Object.values(CATEGORY_LABEL))('renders the %p category chips', label => {
-  render(<ImagesFilterPanel {...defaultProps} />);
+it.each(Object.values(CATEGORY_LABEL))(
+  'renders the %p category chips',
+  label => {
+    render(<ImagesFilterPanel {...defaultProps} />);
 
-  expect(screen.getByText(label)).toBeInTheDocument();
-});
+    expect(screen.getByText(label)).toBeInTheDocument();
+  },
+);
 
 it('marks the selected category as checked', () => {
   render(<ImagesFilterPanel {...defaultProps} selectedCategory="nature" />);
@@ -56,9 +62,23 @@ it('calls onCategoryClick with category key when clicking a chip', () => {
 it('calls onCloseClick when clicking the close button', () => {
   render(<ImagesFilterPanel {...defaultProps} />);
 
-  const closeButton = screen.getByRole('button');
-
-  fireEvent.click(closeButton);
+  fireEvent.click(screen.getByTestId('close-button'));
 
   expect(onCloseClick).toHaveBeenCalled();
+});
+
+it('calls onShareClick when clicking the share button', () => {
+  render(<ImagesFilterPanel {...defaultProps} />);
+
+  fireEvent.click(screen.getByTestId('share-button'));
+
+  expect(onShareClick).toHaveBeenCalledWith(null);
+});
+
+it('does not render the share button when clipboard is not supported', () => {
+  render(
+    <ImagesFilterPanel {...defaultProps} isClipboardSupported={false} />,
+  );
+
+  expect(screen.queryByTestId('share-button')).not.toBeInTheDocument();
 });

--- a/src/app/_providers/themed-toast-container/ThemedToastContainer.component.tsx
+++ b/src/app/_providers/themed-toast-container/ThemedToastContainer.component.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useColorScheme } from '@mui/material/styles';
+import { ToastContainer } from 'react-toastify';
+
+function ThemedToastContainer() {
+  const { mode, systemMode } = useColorScheme();
+  const toastTheme = systemMode || mode;
+
+  return <ToastContainer icon={false} theme={toastTheme ?? 'light'} />;
+}
+
+export default ThemedToastContainer;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,12 +4,14 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '@lib/mui/theme/theme.config';
+import ThemedToastContainer from './_providers/themed-toast-container/ThemedToastContainer.component';
 
 function Providers({ children }: { children: React.ReactNode }) {
   return (
     <AppRouterCacheProvider>
       <ThemeProvider theme={theme}>
         <CssBaseline />
+        <ThemedToastContainer />
         {children}
       </ThemeProvider>
     </AppRouterCacheProvider>

--- a/src/shared/hooks/use-clipboard/__tests__/useClipboard.hooks.test.ts
+++ b/src/shared/hooks/use-clipboard/__tests__/useClipboard.hooks.test.ts
@@ -1,0 +1,125 @@
+import { renderHook, act } from '@testing-library/react';
+import { toast } from 'react-toastify';
+import useClipboard from '../useClipboard.hooks';
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('#useClipboard', () => {
+  const originalClipboard = navigator.clipboard;
+  const mockWriteText = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('returns isClipboardSupported as true when clipboard is supported', () => {
+    const { result } = renderHook(() => useClipboard({ message: 'Success' }));
+
+    expect(result.current.isClipboardSupported).toBe(true);
+  });
+
+  it('calls writeText with correct text', async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const textToCopy = 'Hello World';
+
+    const { result } = renderHook(() => useClipboard({ message: 'Success' }));
+
+    await act(async () => {
+      await result.current.copy(textToCopy);
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith(textToCopy);
+  });
+
+  it('shows success toast', async () => {
+    const message = 'Copied successfully!';
+
+    const { result } = renderHook(() => useClipboard({ message }));
+
+    await act(async () => {
+      await result.current.copy('Hello World');
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(message);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast when writeText fails', async () => {
+    mockWriteText.mockRejectedValue(new Error('Write failed'));
+
+    const { result } = renderHook(() => useClipboard({ message: 'Success' }));
+
+    await act(async () => {
+      await result.current.copy('text');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Erro ao copiar para a área de transferência!',
+    );
+  });
+
+  it('calls toast error when clipboard is not supported', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useClipboard({ message: 'Success' }));
+
+    await act(async () => {
+      await result.current.copy('text');
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Clipboard não suportado neste navegador',
+    );
+  });
+
+  it('does not call writeText when clipboard is not supported', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useClipboard({ message: 'Success' }));
+
+    await act(async () => {
+      await result.current.copy('text');
+    });
+
+    expect(mockWriteText).not.toHaveBeenCalled();
+  });
+
+  it('returns isClipboardSupported as false when clipboard is not supported', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useClipboard({ message: 'Success' }));
+
+    expect(result.current.isClipboardSupported).toBe(false);
+  });
+});

--- a/src/shared/hooks/use-clipboard/useClipboard.hooks.ts
+++ b/src/shared/hooks/use-clipboard/useClipboard.hooks.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { toast } from 'react-toastify';
+
+type UseClipboardProps = {
+  message: string;
+};
+
+type UseClipboardReturn = {
+  isClipboardSupported: boolean;
+  copy: (text: string) => Promise<void>;
+};
+
+const useClipboard = ({ message }: UseClipboardProps): UseClipboardReturn => {
+  const isClipboardSupported =
+    typeof window !== 'undefined' && !!navigator.clipboard;
+
+  const copy = useCallback(
+    async (text: string) => {
+      if (!isClipboardSupported) {
+        toast.error('Clipboard não suportado neste navegador');
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(text);
+
+        toast.success(message);
+      } catch (error) {
+        toast.error('Erro ao copiar para a área de transferência!');
+
+        console.error('Erro ao copiar:', error);
+      }
+    },
+    [isClipboardSupported, message],
+  );
+
+  return {
+    isClipboardSupported,
+    copy,
+  };
+};
+
+export default useClipboard;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4700,6 +4700,13 @@ react-responsive-masonry@^2.7.1:
   resolved "https://registry.yarnpkg.com/react-responsive-masonry/-/react-responsive-masonry-2.7.1.tgz#d27b734fe579034cf26af12f42e42f29a332c0b3"
   integrity sha512-Q+u+nOH87PzjqGFd2PgTcmLpHPZnCmUPREHYoNBc8dwJv6fi51p9U6hqwG8g/T8MN86HrFjrU+uQU6yvETU7cA==
 
+react-toastify@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.5.tgz#ce4c42d10eeb433988ab2264d3e445c4e9d13313"
+  integrity sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==
+  dependencies:
+    clsx "^2.1.1"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"


### PR DESCRIPTION
# Descrição

Este PR adiciona funcionalidade de compartilhamento de imagens através de botão que copia o link atual (com filtros de categoria aplicados) para a área de transferência. Implementa custom hook `useClipboard` com integração da biblioteca `react-toastify` para notificações de feedback ao usuário.

## Como isso foi testado?

- Testes Unitários

